### PR TITLE
Check length of ['len'] before referencing it

### DIFF
--- a/src/Mtdowling/Supervisor/EventListener.php
+++ b/src/Mtdowling/Supervisor/EventListener.php
@@ -99,7 +99,12 @@ class EventListener
                 continue;
             }
             $headers = EventNotification::parseData($input);
-            $payload = fread($this->inputStream, (int) $headers['len']);
+            // PHP 5.6 doesn't deal gracefully with this causing a buffer overflow
+            $payload = '';
+            if (isset($headers['len'])) {
+              $payload = fread($this->inputStream, (int) $headers['len']);
+            }
+
             $notification = new EventNotification($input, $payload, $headers);
             $result = call_user_func($callback, $this, $notification);
             if (true === $result) {


### PR DESCRIPTION
Starting/Stopping of agents doesn't get processed correctly when using this as a listener in php 5.6, possibly earlier versions. The listener simply prints LISTENLOG with a var_export($event->getData, true).

Utilizing http://supervisord.org/events.html as a reference

``` bash
/usr/local/bin/php /usr/local/supervisord_listener.php
processname:cat groupname:cat from_state:STOPPED


'fread(): Length parameter must be greater than 0' in file /usr/local/agent/license/sharedias/vendor/mtdowling/supervisor-event/src/Mtdowling/Supervisor/EventListener.php at line 102
LISTENLOG array (
  'processname' => 'cat',
  'groupname' => 'cat',
  'from_state' => 'STOPPED',
)
RESULT 2
OKREADY
```

This leads to the event listener overflowing when utilized by supervisord. With this fix:

``` bash
/usr/local/bin/php /usr/local/supervisord_listener.php
processname:cat groupname:cat from_state:STOPPED
LISTENLOG array (
  'processname' => 'cat',
  'groupname' => 'cat',
  'from_state' => 'STOPPED',
)

RESULT 2
OKREADY
```
