### PR TITLE
issues/3 : make len event parameter mendatory

### DIFF
--- a/src/Mtdowling/Supervisor/EventListener.php
+++ b/src/Mtdowling/Supervisor/EventListener.php
@@ -95,7 +95,8 @@ class EventListener
         $this->sendReady();
 
         while (true) {
-            if (!$input = trim($this->readLine())) {
+            $input = trim($this->readLine());
+            if (!$input || !preg_match('#len:#', $input)) {
                 continue;
             }
             $headers = EventNotification::parseData($input);


### PR DESCRIPTION
Pull request for issue : #3 

i have add extra check from the readLine as few line bellow it is use for reading the payload. i simply ignore any message which does not, at least, contain `len:` followed by any number.